### PR TITLE
Suppress multiple match warning where it causes test errors

### DIFF
--- a/R/radf-tidiers.R
+++ b/R/radf-tidiers.R
@@ -356,10 +356,10 @@ tidy_join.radf_obj <- function(x, y = NULL, ...) {
   }
 
   join_by <- if (!is_mc(y)) c("id") else NULL
-  full_join(
+  suppress_matches_multiple_warning(full_join(
     tidy(x, format = "long"),
     tidy(y, format = "long"),
-    by = c("stat", join_by)) %>%
+    by = c("stat", join_by))) %>%
     mutate(
       id = factor(id, levels = series_names(x)),
       stat = factor(stat, levels = c("adf", "sadf", "gsadf"))) %>%
@@ -608,12 +608,12 @@ augment_join.radf_obj <- function(x, y = NULL, trunc = TRUE, ...) {
   # key_if_date <- if (is_idx_date) "key"  else NULL
   id_lvls <- if (is_panel) "panel" else series_names(x)
 
-  full_join(
+  suppress_matches_multiple_warning(full_join(
     augment(x, "long", panel = is_panel, trunc = trunc),
     augment(y, "long", trunc = trunc) %>%
       select_at(vars(-all_of(idx_if_date))),
     by = c("key", "stat", join_by)
-  ) %>%
+  )) %>%
     drop_na(index) %>%
     mutate(id = factor(id, levels = id_lvls)) %>%
     arrange(id, stat, sig) #%>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -148,3 +148,16 @@ is_wb <- function(y) {
 is_sb <- function(y) {
   get_method(y) %||% FALSE == "Sieve Bootstrap"
 }
+
+# TODO: Remove after dplyr 1.1.0 is released and use `multiple = "all"` instead
+suppress_matches_multiple_warning <- function(expr) {
+  handler_matches_multiple <- function(cnd) {
+    if (inherits(cnd, "dplyr_warning_join_matches_multiple")) {
+      restart <- findRestart("muffleWarning")
+      if (!is.null(restart)) {
+        invokeRestart(restart)
+      }
+    }
+  }
+  withCallingHandlers(expr, warning = handler_matches_multiple)
+}


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, we need to work around broken tests of yours that were expecting no output. I've done that by suppressing the multiple-match warning that appears in dplyr 1.1.0 (it wont have any effect with other dplyr versions). I've only suppressed it on join calls that cause errors in the tests when a warning is thrown.

We plan to submit dplyr 1.1.0 on January 27th.

This patch should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!