### PR TITLE
Use `relationship` on dplyr >=1.1.0.9000

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -148,16 +148,3 @@ is_wb <- function(y) {
 is_sb <- function(y) {
   get_method(y) %||% FALSE == "Sieve Bootstrap"
 }
-
-# TODO: Remove after dplyr 1.1.0 is released and use `multiple = "all"` instead
-suppress_matches_multiple_warning <- function(expr) {
-  handler_matches_multiple <- function(cnd) {
-    if (inherits(cnd, "dplyr_warning_join_matches_multiple")) {
-      restart <- findRestart("muffleWarning")
-      if (!is.null(restart)) {
-        invokeRestart(restart)
-      }
-    }
-  }
-  withCallingHandlers(expr, warning = handler_matches_multiple)
-}


### PR DESCRIPTION
We are preparing to release dplyr 1.1.1 and this package popped up in the revdep checks.

We realized that we didn't get the `multiple` argument quite right the first time around 😞 . It was too aggressive since it warned on both one-to-many and many-to-many joins. In 1.1.1 we've made two improvements:
- `multiple` now defaults to `"all"`. The options of `NULL`, `"error"`, and `"warning"` are deprecated.
- `relationship` is a new argument to add known constraints onto the join procedure, such as `"many-to-one"`, which replaces `multiple = "error"`.

The default of `relationship` checks to see if there is a `many-to-many` relationship between the keys of `x` and `y` and will warn if one is present. This should be _much_ rarer than what we checked for before, and targets the most dangerous case that we were trying to warn the user about.

You can read all about `relationship` here https://github.com/tidyverse/dplyr/pull/6753, along with the issues linked there.

Unfortunately it does affect some tests here. I think the easiest thing to do is to just branch off the dplyr version that is installed and set `relationship = "many-to-many"` or `multiple = "all"` accordingly.

We plan to submit dplyr 1.1.1 in 2-3 weeks.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!